### PR TITLE
Reduce spacing on the welcome page top part, to make the news more visible

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 
-  <div class="flex-l mt2 mw8 center">
-    <article class="center cf pv5 ph3 ph4-ns mw7">
+  <div class="flex-l mt2 w-70-ns center">
+    <article class="center cf pv2 ph3 ph4-ns w-100">
       <div class="nested-copy-line-height lh-copy f4 nested-links nested-img mid-gray">
         {{ .Content }}
       </div>


### PR DESCRIPTION
Current website it is unclear on monitors that there is a recent news section, this pulls it up by reducing the space used by the top text.

| a | b |
| --- | ---|
| Before | ![image](https://user-images.githubusercontent.com/5221158/192788630-e7b10419-70b5-4d36-b29a-a336eabee745.png) | 
| After | ![image](https://user-images.githubusercontent.com/5221158/192788759-b2ccc239-4758-4b42-a9db-f657aab023a6.png) |

This also works on none-widescreen. The spacing is equal to the news item sumary