### PR TITLE
Change size and positionaing of logos

### DIFF
--- a/assets/ananke/css/footer.css
+++ b/assets/ananke/css/footer.css
@@ -1,18 +1,17 @@
-.sponsor {
-    width: 100%;
-}
-
-.sponsorLabel {
+.sponsor span {
     display: inline-flex;
     height: 1em;
     color: black;
     align-self: center;
+    font-weight: bold;
 }
 
-.sponsor > div {
-    padding-right: 10px;
+div.sponsor {
+    flex-flow: row wrap;
+    gap: 10px;
 }
 
-.sponsor > img {
-    max-height: 250px;
+.sponsor img {
+    margin: 50px;
+    max-width: 350px;
 }

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -1,27 +1,27 @@
-<footer class="bg-white bottom-0 w-100 pa3" role="contentinfo">
-<div class="flex flex-column justify-around">
-   <img src="/sponsors/icpc.webp" alt="NWERC">
-    <div class="flex justify-between sponsor">
-        <div class="flex flex-column">
+<footer class="bg-white bottom-0 w-100" role="contentinfo">
+<div class="flex flex-column justify-around pa3 pb5">
+   <img src="/sponsors/icpc.webp" alt="NWERC" class="w-100 mw9 center">
+    <div class="flex justify-between w-100 center sponsor">
+        <div class="flex flex-column center">
             <img src="/sponsors/imc.webp" alt="IMC Trading">
-            <b class="sponsorLabel">Platinum Sponsor</b>
+            <span>Platinum Sponsor</span>
         </div>
-        <div class="flex flex-column">
+        <div class="flex flex-column center">
             <img src="/sponsors/jane-street.webp" alt="Jane Street">
-            <b class="sponsorLabel">Gold Sponsor</b>
+            <span>Gold Sponsor</span>
         </div>
-        <div class="flex flex-column">
+        <div class="flex flex-column center">
             <img src="/sponsors/netcompany.webp" alt="Netcompany">
-            <b class="sponsorLabel">Gold Sponsor</b>
+            <span>Gold Sponsor</span>
         </div>
-        <div class="flex flex-column">
+        <div class="flex flex-column center">
             <img src="/sponsors/flowtraders.webp" alt="Flowtraders">
-            <b class="sponsorLabel">Gold Sponsor</b>
+            <span>Gold Sponsor</span>
         </div>
     </div>
 </div>
-<div class="flex justify-between">
-    <a class="f4 fw4 hover-black no-underline black-70 dn dib-ns pv2 ph3" href="{{ .Site.Home.Permalink }}" >
+<div class="flex justify-between {{ .Site.Params.background_color_class | default "bg-black" }} pa3">
+    <a class="f4 fw4 hover-white no-underline white-70 dn dib-ns pv2 ph3" href="{{ .Site.Home.Permalink }}" >
         &copy; {{ with .Site.Copyright | default .Site.Title }} {{ . | safeHTML }} {{ now.Format "2006"}} {{ end }}
     </a>
     <div>{{ partial "social-follow.html" . }}</div>


### PR DESCRIPTION
For me, safari did this:
<img width="1000" alt="Schermafbeelding 2022-10-13 om 18 21 23" src="https://user-images.githubusercontent.com/13507227/195651698-1bcf7438-e93a-4aa6-87cd-e4b6023ee311.png">

And chrome didn't show the sponsor level
<img width="1000" alt="Schermafbeelding 2022-10-13 om 18 21 50" src="https://user-images.githubusercontent.com/13507227/195651797-b7fe2c72-e92e-471d-a77d-d8e0fe4a05bd.png">

Also I thought the icpc banner was associaal groot, and the logos should have more whitespace.

This PR (i think) fixes this.