### PR TITLE
Fix sponser logo sizes on mobile

### DIFF
--- a/assets/ananke/css/footer.css
+++ b/assets/ananke/css/footer.css
@@ -13,5 +13,6 @@ div.sponsor {
 
 .sponsor img {
     margin: 50px;
-    max-width: 350px;
+    width: 350px;
+    max-width: calc(100% - 100px);
 }


### PR DESCRIPTION
A sponsor logo will now never be wider than the box it should fit in

Preview:
![image](https://user-images.githubusercontent.com/19886044/195680227-30863192-31a4-4b9e-af3e-000afe254a94.png)
