### PR TITLE
Update the teams and add the pc numbers.

### DIFF
--- a/content/teams.md
+++ b/content/teams.md
@@ -5,75 +5,74 @@ draft: false
 type: page
 menu: main
 ---
-The following teams are competing in NWERC 2022.
-|          |                                                                          |
-:---------:|--------------------------------------------------------------------------|
-| ![U-4786] | <ul><li>NP-easy</li><li>Segmenttikuu</li></ul> |
-| ![U-7] | <ul><li>Dijkstra's Dynamite</li><li>Code NoWERC</li></ul> |
-| ![U-7464] | <ul><li>1966</li></ul> |
-| ![U-3397] | <ul><li>LatLaget</li><li>O(no!)</li><li>IT-Böys</li></ul> |
-| ![U-367] | <ul><li>Segfault go BRRRR</li><li>ADA Refactor</li><li>Chindia Targoviste</li><li>WA & Chill</li><li>Exponential Fenwick</li></ul> |
-| ![U-452] | <ul><li>Piece of cake</li><li>Duck-Team\%</li><li>CoffeeBeans</li><li>RookieMistake</li><li>Runtime Error</li></ul> |
-| ![U-573] | <ul><li>Fully Autonomous Unicycle</li><li>Fully Autonomous Unicorns</li></ul> |
-| ![U-3546] | <ul><li>heap heap hoera</li></ul> |
-| ![U-8170] | <ul><li>Hexaflexagons</li><li>Seems to be O(k!)</li></ul> |
-| ![U-20052] | <ul><li>Kleinsche Flaschen</li><li>HHU Runtime Terror</li></ul> |
-| ![U-14277] | <ul><li>Pie-Oh-Near</li></ul> |
-| ![U-7019] | <ul><li>SExon;</li></ul> |
-| ![U-3678] | <ul><li>IMPostors</li><li>Box Street</li><li>Anonymous Sigmaz</li></ul> |
-| ![U-6864] | <ul><li>We’re just here for the balloons</li><li>~ Python Pirates</li><li>Ctrl Alt Elite</li></ul> |
-| ![U-18106] | <ul><li>Jacobs Rules</li><li>chill club</li><li>skibidi wa4 pa</li><li>Team 4</li><li>Team 5</li></ul> |
-| ![U-2272] | <ul><li>Tzatzikitartare</li><li>Kindergarten Timelimit</li><li>Exploding KITtens</li></ul> |
-| ![U-980] | <ul><li>KTU#1</li><li>KTU#2</li></ul> |
-| ![U-3758] | <ul><li>Lille Skutt</li></ul> |
-| ![U-1088] | <ul><li>Plopkoek</li><li>Contra Spem Spero</li><li>0b10101</li></ul> |
-| ![U-1097] | <ul><li>Dal Dal Doma</li><li>Gecko Kickers</li></ul> |
-| ![U-1112] | <ul><li>ezcp</li><li>Noobs@LTH</li><li>ECON 101</li></ul> |
-| ![U-1362] | <ul><li>proggecribben</li><li>icpC++</li></ul> |
-| ![U-8002] | <ul><li>Reckless Raccoons</li><li>Bidoof Aron Piplup Cyndaquil</li><li>Reduce all the things</li></ul> |
-| ![U-3403] | <ul><li>Hakk og Spaghetti</li></ul> |
-| ![U-1534] | <ul><li>Balloon Addicts, Passionate Coders</li><li>Rodina</li><li>The Pool Party</li><li>3Guys1Segfault</li></ul> |
-| ![U-3787] | <ul><li>Ich hab studiert</li><li>Leberkäs</li></ul> |
-| ![U-2267] | <ul><li>⊛˯⛒</li><li>Reihe 12 <(òvó)></li><li>ƟvƟ</li></ul> |
-| ![U-11054] | <ul><li>fft enthusiasts</li><li>Segfault: SyntaxError</li></ul> |
-| ![U-4278] | <ul><li>The floor is made of Java</li><li>Lord of the Graphs</li></ul> |
-| ![U-1917] | <ul><li>Expecto PatroTUM</li><li>Eeylops Owl EmporiTUM</li><li>Avada TUMavra</li><li>LonglongbotTUM</li></ul> |
-| ![U-2061] | <ul><li>Three Lost Physicists</li></ul> |
-| ![U-2274] | <ul><li>Never :q!</li></ul> |
-| ![U-2275] | <ul><li>painfULMess</li></ul> |
-| ![U-1154] | <ul><li>fast faster java</li></ul> |
-| ![U-9858] | <ul><li>Runtime Terror</li><li>ln(0) = 0</li></ul> |
-| ![U-8311] | <ul><li>CPUMONS</li></ul> |
-| ![U-2284] | <ul><li>🇺🇳🇮🇨🇴🇩🇪</li><li>mc</li><li>sop</li><li>Vetter et al.</li><li>Ja, Maar to the Max</li></ul> |
-| ![U-18633] | <ul><li>UNInstAll</li></ul> |
-| ![U-5541] | <ul><li>Dori-NWERC</li><li>Fili-NWERC</li></ul> |
-| ![U-2320] | <ul><li>\u1f0c\u03bb\u03b3\u03bf\u03c2</li><li>Miniputters</li></ul> |
-| ![U-8317] | <ul><li>4th party cookies</li></ul> |
-| ![U-2343] | <ul><li>WHATEVER >~<</li><li>Drzewiec</li><li>anonymous squids</li><li>Trinity's Trinity</li><li>Holland King</li></ul> |
-| ![U-2357] | <ul><li>The Balloon Animals</li><li>Grape</li><li>scream&cout</li></ul> |
-| ![U-5784] | <ul><li>p(r)ogg(ram)ers</li><li>one more try</li></ul> |
-| ![U-6940] | <ul><li>Team 47 once again</li></ul> |
-| ![U-7264] | <ul><li>GAU1</li><li>GAU2</li></ul> |
-| ![U-3330] | <ul><li>Keksi Fan Club</li></ul> |
-| ![U-7887] | <ul><li>f slanga strik</li></ul> |
-| ![U-13859] | <ul><li>NoobCoders</li><li>Black Box</li><li>your local bruh moment dealers</li></ul> |
-| ![U-5737] | <ul><li>robuman</li><li>Team DSD</li></ul> |
-| ![U-3749] | <ul><li>Algocrats</li><li>Algorats</li></ul> |
-| ![U-2467] | <ul><li>0x000000 0xF4A7BB</li><li>The Ash Lads</li></ul> |
-| ![U-3620] | <ul><li>2Palinca1Rakija</li><li>Placeholder team name</li><li>lamelame</li></ul> |
-| ![U-8102] | <ul><li>UPgreat</li></ul> |
-| ![U-6859] | <ul><li>The House Crew</li><li>Mariens</li></ul> |
-| ![U-2526] | <ul><li>KalaPüügiSeadus</li><li>Bubblegum Bitset</li></ul> |
-| ![U-6929] | <ul><li>Team W</li><li>The Error Addicts</li></ul> |
-| ![U-2625] | <ul><li>IT giet oan</li><li>Crystal Math 3.0</li><li>Kerrie vlek</li><li>Team biem</li></ul> |
-| ![U-7477] | <ul><li>VILNIUS TECH 1</li><li>VILNIUS TECH 2</li><li>SAD Team</li></ul> |
-| ![U-2643] | <ul><li>#define true rand</li><li>Hope It Passes</li></ul> |
-| ![U-2664] | <ul><li>PPAP</li><li>Monki IQ 200 (combined)</li><li>forgotten</li><li>std::string name = getTeamName();</li></ul> |
+The following teams are competing in NWERC 2022. The numbers in brackets represent the location of the team work station.
 
+|            |                                                                                                                                                              |
+|:----------:|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ![U-4786]  | <ul><li>NP-easy (100)</li><li>Segmenttikuu (37)</li></ul>                                                                                                    |
+|   ![U-7]   | <ul><li>Dijkstra's Dynamite (54)</li><li>Code NoWERC (110)</li></ul>                                                                                         |
+| ![U-7464]  | <ul><li>1966 (42)</li></ul>                                                                                                                                  |
+| ![U-3397]  | <ul><li>LatLaget (27)</li><li>O(no!) (147)</li><li>IT-Böys (84)</li></ul>                                                                                    |
+|  ![U-367]  | <ul><li>Segfault go BRRRR (4)</li><li>ADA Refactor (72)</li><li>Chindia Targoviste (89)</li><li>WA & Chill (137)</li><li>Exponential Fenwick (123)</li></ul> |
+|  ![U-452]  | <ul><li>Piece of cake (35)</li><li>Duck-Team\% (25)</li><li>CoffeeBeans (81)</li><li>RookieMistake (124)</li><li>Runtime Error (148)</li></ul>               |
+|  ![U-573]  | <ul><li>Fully Autonomous Unicycle (8)</li><li>Fully Autonomous Unicorns (93)</li></ul>                                                                       |
+| ![U-3546]  | <ul><li>heap heap hoera (43)</li></ul>                                                                                                                       |
+| ![U-8170]  | <ul><li>Hexaflexagons (57)</li><li>Seems to be O(k!) (5)</li></ul>                                                                                           |
+| ![U-20052] | <ul><li>Kleinsche Flaschen (73)</li><li>HHU Runtime Terror (141)</li></ul>                                                                                   |
+| ![U-14277] | <ul><li>Pie-Oh-Near (26)</li></ul>                                                                                                                           |
+| ![U-7019]  | <ul><li>SExon; (68)</li></ul>                                                                                                                                |
+| ![U-3678]  | <ul><li>IMPostors (14)</li><li>Box Street (55)</li><li>Anonymous Sigmaz (97)</li></ul>                                                                       |
+| ![U-6864]  | <ul><li>We’re just here for the balloons (66)</li><li>~ Python Pirates (88)</li><li>Ctrl Alt Elite (149)</li></ul>                                           |
+| ![U-18106] | <ul><li>Jacobs Rules (53)</li><li>chill club (83)</li><li>skibidi wa4 pa (102)</li><li>Looking for a job (122)</li><li>Team 5 (145)</li></ul>                |
+| ![U-2272]  | <ul><li>Tzatzikitartare (1)</li><li>Kindergarten Timelimit (65)</li><li>Exploding KITtens (98)</li></ul>                                                     |
+|  ![U-980]  | <ul><li>KTU#1 (50)</li><li>KTU#2 (104)</li></ul>                                                                                                             |
+| ![U-3758]  | <ul><li>Lille Skutt (106)</li></ul>                                                                                                                          |
+| ![U-1039]  | <ul><li>CyanForces\-\-? (75)</li></ul>                                                                                                                       |
+| ![U-1088]  | <ul><li>Plopkoek (52)</li><li>Contra Spem Spero (96)</li><li>0b10101 (136)</li></ul>                                                                         |
+| ![U-1097]  | <ul><li>Dal Dal Doma (58)</li><li>Gecko Kickers (108)</li></ul>                                                                                              |
+| ![U-1112]  | <ul><li>ezcp (23)</li><li>Noobs@LTH (143)</li><li>ECON 101 (95)</li></ul>                                                                                    |
+| ![U-1362]  | <ul><li>proggecribben (33)</li><li>icpC++ (113)</li></ul>                                                                                                    |
+| ![U-8002]  | <ul><li>Reckless Raccoons (21)</li><li>Bidoof Aron Piplup Cyndaquil (13)</li><li>Reduce all the things (114)</li></ul>                                       |
+| ![U-3403]  | <ul><li>Hakk og Spaghetti (64)</li></ul>                                                                                                                     |
+| ![U-1534]  | <ul><li>Balloon Addicts, Passionate Coders (29)</li><li>Rodina (111)</li><li>The Pool Party (140)</li><li>3Guys1Segfault (91)</li></ul>                      |
+| ![U-3787]  | <ul><li>Ich hab studiert (18)</li><li>Leberkäs (115)</li></ul>                                                                                               |
+| ![U-2267]  | <ul><li>⊛˯⛒ (61)</li><li>Reihe 12 <(òvó)> (12)</li><li>ƟvƟ (126)</li></ul>                                                                                   |
+| ![U-11054] | <ul><li>fft enthusiasts (62)</li><li>Segfault: SyntaxError (116)</li></ul>                                                                                   |
+| ![U-4278]  | <ul><li>The floor is made of Java (46)</li><li>Lord of the Graphs (118)</li></ul>                                                                            |
+| ![U-1917]  | <ul><li>Expecto PatroTUM (87)</li><li>Eeylops Owl EmporiTUM (32)</li><li>Avada TUMavra (138)</li><li>LonglongbotTUM (78)</li></ul>                           |
+| ![U-2061]  | <ul><li>Three Lost Physicists (74)</li></ul>                                                                                                                 |
+| ![U-2274]  | <ul><li>Never :q! (22)</li></ul>                                                                                                                             |
+| ![U-2275]  | <ul><li>painfULMess (44)</li></ul>                                                                                                                           |
+| ![U-1154]  | <ul><li>fast faster java (36)</li></ul>                                                                                                                      |
+| ![U-9858]  | <ul><li>Runtime Terror (48)</li><li>ln(0) = 0 (117)</li></ul>                                                                                                |
+| ![U-8311]  | <ul><li>CPUMONS (39)</li></ul>                                                                                                                               |
+| ![U-2284]  | <ul><li>🇺🇳🇮🇨🇴🇩🇪 (31)</li><li>mc (94)</li><li>sop (103)</li><li>Vetter et al. (146)</li><li>Ja, Maar to the Max (128)</li></ul>                        |
+| ![U-18633] | <ul><li>UNInstAll (69)</li></ul>                                                                                                                             |
+| ![U-5541]  | <ul><li>Dori-NWERC (34)</li><li>Fili-NWERC (119)</li></ul>                                                                                                   |
+| ![U-2320]  | <ul><li>\u1f0c\u03bb\u03b3\u03bf\u03c2 (16)</li><li>Miniputters (121)</li></ul>                                                                              |
+| ![U-8317]  | <ul><li>4th party cookies (76)</li></ul>                                                                                                                     |
+| ![U-2343]  | <ul><li>WHATEVER >~< (143)</li><li>Drzewiec (85)</li><li>Trinity's Trinity (3)</li><li>Holland King (47)</li><li>anonymous squids (112)</li></ul>            |
+| ![U-2357]  | <ul><li>The Balloon Animals (2)</li><li>Grape (82)</li><li>scream&cout (139)</li></ul>                                                                       |
+| ![U-5784]  | <ul><li>p(r)ogg(ram)ers (59)</li><li>one more try (9)</li></ul>                                                                                              |
+| ![U-6940]  | <ul><li>Team 47 once again (80)</li></ul>                                                                                                                    |
+| ![U-7264]  | <ul><li>GAU1 (49)</li><li>GAU2 (127)</li></ul>                                                                                                               |
+| ![U-3330]  | <ul><li>Keksi Fan Club (10)</li></ul>                                                                                                                        |
+| ![U-7887]  | <ul><li>f slanga strik (41)</li></ul>                                                                                                                        |
+| ![U-13859] | <ul><li>NoobCoders (99)</li><li>Black Box (134)</li><li>your local bruh moment dealers (56)</li></ul>                                                        |
+| ![U-5737]  | <ul><li>robuman (20)</li><li>Team DSD (63)</li></ul>                                                                                                         |
+| ![U-3749]  | <ul><li>Algocrats (24)</li><li>Algorats (67)</li></ul>                                                                                                       |
+| ![U-2467]  | <ul><li>0x000000 0xF4A7BB (131)</li><li>The Ash Lads (70)</li></ul>                                                                                          |
+| ![U-3620]  | <ul><li>2Palinca1Rakija (6)</li><li>Placeholder team name (51)</li><li>lamelame (130)</li></ul>                                                              |
+| ![U-8102]  | <ul><li>UPgreat (40)</li></ul>                                                                                                                               |
+| ![U-6859]  | <ul><li>The House Crew (38)</li><li>Mariens (132)</li></ul>                                                                                                  |
+| ![U-2526]  | <ul><li>KalaPüügiSeadus (107)</li><li>Bubblegum Bitset (19)</li></ul>                                                                                        |
+| ![U-6929]  | <ul><li>Team W (28)</li><li>The Error Addicts (71)</li></ul>                                                                                                 |
+| ![U-2625]  | <ul><li>IT giet oan (17)</li><li>Crystal Math 3.0 (86)</li><li>Kerrie vlek (109)</li><li>Team biem (144)</li></ul>                                           |
+| ![U-7477]  | <ul><li>VILNIUS TECH 1 (79)</li><li>VILNIUS TECH 2 (133)</li><li>SAD Team (92)</li></ul>                                                                     |
+| ![U-2643]  | <ul><li>#define true rand (7)</li><li>Hope It Passes (125)</li></ul>                                                                                         |
+| ![U-2664]  | <ul><li>PPAP (77)</li><li>Monki IQ 200 (combined) (101)</li><li>std::string name = getTeamName(); (11)</li></ul>                                             |
 
 [U-7]: /logo/U-7.png "Aarhus University"
-[U-290]: /logo/U-290.png "Christian-Albrechts-Universitaet zu Kiel"
-[U-362]: /logo/U-362.png "Darmstadt University of Technology"
 [U-367]: /logo/U-367.png "Delft University of Technology"
 [U-452]: /logo/U-452.png "Eindhoven University of Technology"
 [U-573]: /logo/U-573.png "Friedrich-Alexander-University Erlangen-Nuremberg"
@@ -114,9 +113,6 @@ The following teams are competing in NWERC 2022.
 [U-5541]: /logo/U-5541.png "University of Bath"
 [U-5737]: /logo/U-5737.png "University of Manchester"
 [U-5784]: /logo/U-5784.png "University of Edinburgh"
-[U-6026]: /logo/U-6026.png "Molde University College"
-[U-6557]: /logo/U-6557.png "Frankfurt University of Applied Sciences"
-[U-6638]: /logo/U-6638.png "German University of Technology in Oman"
 [U-6859]: /logo/U-6859.png "University of Southampton"
 [U-6864]: /logo/U-6864.png "IT University of Copenhagen"
 [U-6929]: /logo/U-6929.png "University of Warwick"
@@ -126,7 +122,6 @@ The following teams are competing in NWERC 2022.
 [U-7464]: /logo/U-7464.png "Brunel University London"
 [U-7477]: /logo/U-7477.png "Vilnius Gediminas Technical University"
 [U-7887]: /logo/U-7887.png "University of Iceland"
-[U-7950]: /logo/U-7950.png "University of Birmingham"
 [U-8002]: /logo/U-8002.png "Radboud University"
 [U-8102]: /logo/U-8102.png "University of Passau"
 [U-8170]: /logo/U-8170.png "Hasso Plattner Institute"

--- a/content/teams.md
+++ b/content/teams.md
@@ -5,7 +5,7 @@ draft: false
 type: page
 menu: main
 ---
-The following teams are competing in NWERC 2022. The numbers in brackets represent the location of the team work station.
+The following teams are competing in NWERC 2022. The numbers in parentheses represent the location of the team's workstation.
 
 |            |                                                                                                                                                              |
 |:----------:|--------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Adding the workspace numbers for coaches is a holy grail. We don't have to look it up for all coaches, rather tell them to check the website.