### PR TITLE
Add livestream URLs

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -10,3 +10,26 @@ Welcome to the website of the NWERC 2022!
 The Northwestern Europe Regional Contest (NWERC) is a contest in which teams from universities all over the Northwestern part of Europe are served a series of algorithmic problems. The goal of each team is to solve as many problems as possible within the 5 hour time limit. Potential solutions are submitted and corrected by an automated judging system. The team that solves the most problems at the end of the contest qualifies for the ICPC World Finals.
 
 The 2022 edition of the Northwestern European Regional Contest (NWERC) will be held on the 25th of November until the 27th of November 2022. The contest will be held on the campus of the Delft University of Technology.
+
+<!--
+{{% row %}}
+{{% column %}}
+
+## Contest material
+
+- TODO: add live scoreboard and mirror contest here
+- [Contest Livestream](https://youtu.be/aDsW8J8P7go)
+- [Award Ceremony Livestream](https://youtu.be/nbr_v73cvfQ)
+
+{{% /column %}}
+{{% column %}}
+
+## Test session material
+
+- TODO: add live scoreboard here
+- [Opening Ceremony Livestream](https://youtu.be/nvOgM5o3uMk)
+- [Test Session and Team Interviews Livestream](https://youtu.be/33Yw_kqgUGQ)
+
+{{% /column %}}
+{{% /row %}}
+-->

--- a/content/news/livestreams.md
+++ b/content/news/livestreams.md
@@ -1,0 +1,12 @@
+---
+title: "Livestream URLs"
+date: 2022-11-22T09:00:00+01:00
+draft: false
+---
+
+The URLs for the livestreams have already been created, and can be found here:
+
+- [Opening Ceremony Livestream](https://youtu.be/nvOgM5o3uMk)
+- [Test Session and Team Interviews Livestream](https://youtu.be/33Yw_kqgUGQ)
+- [Contest Livestream](https://youtu.be/aDsW8J8P7go)
+- [Award Ceremony Livestream](https://youtu.be/nbr_v73cvfQ)

--- a/layouts/shortcodes/column.html
+++ b/layouts/shortcodes/column.html
@@ -1,0 +1,3 @@
+<div style="flex: 1 0 0%;">
+    {{ .Inner }}
+</div>

--- a/layouts/shortcodes/row.html
+++ b/layouts/shortcodes/row.html
@@ -1,0 +1,3 @@
+<div class="flex-l">
+    {{ .Inner }}
+</div>


### PR DESCRIPTION
I've added a two-column layout, similar to https://2021.nwerc.eu/.
Note that, on smaller screens, the two columns will be rendered vertically.

We can use these sections to later add the scoreboard, problem set, solutions, etc.

![image](https://user-images.githubusercontent.com/9739541/203158441-fd1d8992-a19c-4351-bedf-a49c11b6a879.png)

![image](https://user-images.githubusercontent.com/9739541/203158586-17f56060-19b3-4850-ba2f-2ab896d74d6e.png)
